### PR TITLE
The basic core of the Metanode class were built along with its test c…

### DIFF
--- a/source/MetaRigger/MetaRigger/MetaRigger.pyproj
+++ b/source/MetaRigger/MetaRigger/MetaRigger.pyproj
@@ -22,7 +22,13 @@
     <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="MetaRigger\Metanodes\Metanode.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="MetaRigger\Metanodes\__init__.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="MetaRigger\tests\MetaRigger\Metanodes\testMetanode.py">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="MetaRigger\tests\MetaRigger\Metanodes\__init__.py">

--- a/source/MetaRigger/MetaRigger/MetaRigger/Metanodes/Metanode.py
+++ b/source/MetaRigger/MetaRigger/MetaRigger/Metanodes/Metanode.py
@@ -1,0 +1,88 @@
+import pymel.core
+import inspect
+
+class Metanode(object):
+    """
+    The Metanode class wraps a maya node in the dg graph.
+
+    The Metanode class is the basic building block for a metadata network.
+    A metadata network is a network of nodes that runs parallel to a maya node network and
+    helps with traversing the graph while storing (meta)data information about its content.
+    A metanode class wraps a actual instance of an unknown node in the maya graph.
+    The node is used to contain the actual metadata.
+
+    Attributes:
+        _metaNode : Contains a reference to the actual metanode instance in the graph
+        _type : Contains the class, derived from pymel.core.general.PyNode, that the node is supposed to wrap.
+        _instance : Contains a reference to the instanciated node the class wraps. The node is of the type stored in _type
+
+    Methods:
+        build() : Builds the actual node that is wrapped by the Metanode instance
+    """
+
+    def __init__(self, type=pymel.core.nodetypes.Unknown):
+        """
+        Initialises the Metanode. 
+        
+        A few things happens when a Metanode is initialized.
+        Firstly, a new Unknown node is created in the maya scene and a reference to it is stored in the Metanode class instance.
+        Then the passed in type, which should be a class derived from pymel.core.general.PyNode, is stored inside the Metanode class instance.
+        After this the preInitialization of the class is run to set up the actual metanode instance in the maya scene and the Metanode class instance.
+
+        If a non-class or a class that isn't derived from pymel.core.general.PyNode is passed as the type parameter a TypeError is raised. 
+
+        Arguments:
+            type : A class, derived from pymel.core.general.PyNode, that represents the type of the node that is wrapped by this Metanode class instance.
+
+        Raise:
+            TypeError : Raised when the type parameter is passed has a non-class or a class that isn't derived from pymel.core.general.PyNode.
+        """
+
+        super(Metanode, self).__init__()
+        if (not inspect.isclass(type) or not issubclass(type, pymel.core.general.PyNode)):
+           raise TypeError
+
+        self._metaNode = pymel.core.nodetypes.Unknown()
+        self._type = type
+        self._instance = None
+
+        self._preInitialization()
+
+    def _preInitialization(self):
+        """
+        Performs the needed setUp for the Metanode class instance and the metanode actual node instance.
+
+        During pre-initialization a series of attributes are added to the metanode instance that mirrors some of the data stored by
+        the metanode plus the attribute needed to connect the metanode with other metanodes to create a network.
+
+        After pre-initialization you can expect to have the following attributes of the metanode instance :
+            - _type -> string
+            - _instance -> message ( Not Readable )
+            - _parent -> message ( Not Readable )
+            - _childs -> message ( Not Writable )
+
+        These attributes can be used to reconstruct a Metanode class instance from an actual metanode.
+        Furthermore, the _parent and _childs attribute connections are used to represent relationships in a metanode network.
+        
+        The _instance attribute is used to store a connection to the actual instance  of the node wrapped by this metanode, if already built.
+        """
+
+        self._metaNode.addAttr("_type", dataType = "string")
+        self._metaNode.addAttr("_instance", attributeType = "message", readable = False, writable = True)
+        self._metaNode.addAttr("_parent", attributeType = "message", readable = False, writable = True)
+        self._metaNode.addAttr("_childs", attributeType = "message", readable = True, writable = False)
+
+    def build(self):
+        """
+        Builds the actual node that is wrapped by this metanode.
+        
+        A default instance of a node of type self._type is created if it wasn't already previously built.
+
+        Returns:
+            A reference to the node wrapped by this metanode.
+        """
+
+        if self._instance is None:
+           self._instance = self._type()
+
+        return self._instance

--- a/source/MetaRigger/MetaRigger/MetaRigger/tests/MetaRigger/Metanodes/testMetanode.py
+++ b/source/MetaRigger/MetaRigger/MetaRigger/tests/MetaRigger/Metanodes/testMetanode.py
@@ -1,0 +1,72 @@
+import unittest
+import inspect
+
+import pymel.core
+import MetaRigger.Metanodes.Metanode
+
+
+class Test_testMetanode(unittest.TestCase):
+    def setUp(self):
+        self.metanode = MetaRigger.Metanodes.Metanode.Metanode()
+
+    def test_AMetanodeCreatesAnEmptyMayaNodeWhenInstanciated(self):
+        count = len(pymel.core.ls(type = 'unknown'))
+        MetaRigger.Metanodes.Metanode.Metanode()
+
+        self.assertEqual(len(pymel.core.ls(type = 'unknown')), count + 1, "The Metanode did not create an unknown node.")
+
+    def test_AMetanodeStoresTheNewlyCreatedUnknownNodeAsAnInstanceMember(self):
+        self.assertIsInstance(self.metanode._metaNode, pymel.core.nodetypes.Unknown, "The metanode isn't storing an Uknown node in its member.")
+
+    def test_AMetanodeStoresAPyNodeDerivedClassInIts_typeMember(self):
+        self.assertTrue( inspect.isclass(self.metanode._type), "The _type member isn't storing a class.")
+        self.assertTrue( issubclass(self.metanode._type, pymel.core.general.PyNode), "The _type member isn't storing an child of PyNode." )
+
+    def test_TheMetanodeConstructorRaisesATypeErrorExceptionIfTheTypeArgumentIsntAClassDerivedFromPyNode(self):
+        self.assertRaises(TypeError, MetaRigger.Metanodes.Metanode.Metanode, type = 'notAPynodeClassOrAClassAtAll')
+        self.assertRaises(TypeError, MetaRigger.Metanodes.Metanode.Metanode, type = int)
+
+    def test_TheMetanodeEncapsulatedUnknownNodeHasAStringAttributeCalled_Type(self):
+        self.assertTrue( self.metanode._metaNode.hasAttr("_type"), "The Metanode._metanode node has no type attribute.")
+        self.assertEquals( self.metanode._metaNode._type.type() , "string", "The type attribute isn't a string type.")
+
+    def test_TheMetanodeEncapsulatedUnknownNodeHasAInputMessageAttributeCalled_Instance(self):
+        self.assertTrue( self.metanode._metaNode.hasAttr("_instance"), "The Metanode._metanode node has no _instance attribute.")
+        self.assertEquals( self.metanode._metaNode._instance.type() , "message", "The _instance attribute isn't a message type.")
+
+        self.assertFalse(pymel.core.general.attributeQuery(self.metanode._metaNode._instance.attrName(), node = self.metanode._metaNode.name(), readable = True), "The _instance attribute should not be readable.")
+        self.assertTrue(pymel.core.general.attributeQuery(self.metanode._metaNode._instance.attrName(), node = self.metanode._metaNode.name(), writable = True), "The _instance attribute should be writable.")
+
+    def test_TheMetanodeEncapsulatedUnknownNodeHasAInputMessageAttributeCalled_Parent(self):
+        self.assertTrue( self.metanode._metaNode.hasAttr("_parent"), "The Metanode._metanode node has no _parent attribute.")
+        self.assertEquals( self.metanode._metaNode._parent.type() , "message", "The _parent attribute isn't a message type.")
+
+        self.assertFalse(pymel.core.general.attributeQuery(self.metanode._metaNode._instance.attrName(), node = self.metanode._metaNode.name(), readable = True), "The _parent attribute should not be readable.")
+        self.assertTrue(pymel.core.general.attributeQuery(self.metanode._metaNode._instance.attrName(), node = self.metanode._metaNode.name(), writable = True), "The _parent attribute should be writable.")
+
+    def test_TheMetanodeEncapsulatedUnknownNodeHasAnOutputMessageAttributeCalled_Childs(self):
+        self.assertTrue( self.metanode._metaNode.hasAttr("_childs"), "The Metanode._metanode node has no _childs attribute.")
+        self.assertEquals( self.metanode._metaNode._childs.type() , "message", "The _childs attribute isn't a message type.")
+
+        self.assertTrue(pymel.core.general.attributeQuery(self.metanode._metaNode._childs.attrName(), node = self.metanode._metaNode.name(), readable = True), "The _childs attribute should be readable.")
+        self.assertFalse(pymel.core.general.attributeQuery(self.metanode._metaNode._childs.attrName(), node = self.metanode._metaNode.name(), writable = True), "The _childs attribute should not be writable.")
+
+    def test_TheMetanodeBuildMethodShouldInstanciateANodeOfTheTypeStoredIn_Type(self):
+        builtNode = self.metanode.build()
+
+        self.assertIsInstance(builtNode, self.metanode._type, "The newly built node is not an instance of the class stored in _type.");
+
+    def test_TheMetanodeBuildMethodShouldStoreAReferenceToTheNewlyInstanciatedNodeInIts_InstanceMember(self):
+        builtNode = self.metanode.build()
+
+        self.assertIs(self.metanode._instance, builtNode, "The _instance member is not holding a reference to the newly created node.")
+
+    def test_TheMetanodeBuildMethodShouldNotCreateANewNodeIfTheNodeIsAlreadyBeenBuilt(self):
+        self.metanode.build()
+        count = len(pymel.core.ls())
+        self.metanode.build()
+
+        self.assertEqual(len(pymel.core.ls()), count, "The second call to build has created a new node.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…ases.

A Metanode class is a class that wraps a maya node to store data about it and its construction.
It contains informations about about how the wrapped node relates to other nodes to simplify graph traversal  and rig building.

A metanode is represented in the maya graph with an actual uknown node instance that stores the needed informations in its attribute.